### PR TITLE
Feat: Adds tag specific feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,3 +83,6 @@ titlecase: true
 include: [".htaccess"]
 exclude: ["demo/*", "lib", "config.rb", "Capfile", "config", "Gemfile", "Gemfile.lock", "README.md", "LICENSE", "log", "Rakefile", "Rakefile.rb", "tmp", "less", "*.sublime-project", "*.sublime-workspace", "test", "spec", "Gruntfile.js", "package.json", "node_modules"]
 plugins: [jekyll-paginate, jekyll-feed]
+
+feed:
+  tags: true


### PR DESCRIPTION
With using [`jekyll-feed`](https://github.com/jekyll/jekyll-feed) you have a lot of good options here. Right now the feed gets generated by all options that you've passed in through your frontmatter. You can find a specific feed through an endpoint like `/feed/by_tag/<TAG_NAME>.xml`. So you could go to `/feed/by_tag/architecture.xml`.

If you are like, I only want it to work on X things you can also do:
```yml
feed:
  tags:
    only:
      - tag-to-include
      - another-tag
```

Then you wouldn't generate for off ones. There is also an option to only exclude them by swapping `only` with `except`

If you want to also change the path you can:
```yml
feed:
  tags:
    path: "feeds/"
```
And this will generate them as `/feeds/<TAG_NAME>.xml`